### PR TITLE
Fix error: optional chaining on non-optional value of type 'pthread_t'

### DIFF
--- a/Sources/Spawn/Spawn.swift
+++ b/Sources/Spawn/Spawn.swift
@@ -90,7 +90,11 @@ public final class Spawn {
 
     deinit {
         var status: Int32 = 0
-        pthread_join(tid, nil)
+
+        if let tid = tid {
+            pthread_join(tid, nil)
+        }
+
         waitpid(pid, &status, 0)
     }
 }


### PR DESCRIPTION
This commit fixes error: `Cannot use optional chaining on non-optional value of type 'pthread_t' (aka 'UnsafeMutablePointer<_opaque_pthread_t>')`
