### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Spawn
 
-* Note: Works on OSX and Linux.
- 
+* Note: Works on macOS and Linux.
+
 * Spawn runs new processes using `posix_spawn` and reads output (and stderr stream) on a different thread so the calling thread is never blocked.
 
 # How to use?
 
-Just pass the arguments to execute. For example :
+Just pass the arguments to execute. For example:
 
 ```swift
 import Spawn
 
 do {
-    let spawn = try Spawn(args: ["/bin/sh", "-c", "ls", "."]) { str in 
+    let spawn = try Spawn(args: ["/bin/sh", "-c", "ls", "."]) { str in
         print(str)
     }
 } catch {
@@ -30,7 +30,10 @@ import PackageDescription
 
 let package = Package(
     name: "MyPackage",
-    dependencies: [.Package(url: "https://github.com/aciidb0mb3r/Spawn", majorVersion: 0)]
+
+    dependencies: [
+        .Package(url: "https://github.com/aciidb0mb3r/Spawn", majorVersion: 0)
+    ]
 )
 ```
 


### PR DESCRIPTION
This commit contains:
- change name from `OSX` to `macOS`
- fix typos
- make easier copy-pasting a dependency in `Swift Package Manager`
